### PR TITLE
Dashboard disable mode for updating M365 firmware

### DIFF
--- a/M365/M365.ino
+++ b/M365/M365.ino
@@ -64,6 +64,29 @@ void setup() {
     Message.Process();
   }
 
+  //Check for M365 DashBorad temporary deactivation request
+  if ((S20C00HZ65.brake > 130)&&(S20C00HZ65.throttle > 150))
+  {
+    XIAOMI_PORT.end();
+    pinMode(0, INPUT);
+    pinMode(1, INPUT); 
+    display.set2X();
+    displayClear(1);
+    display.setCursor(0, 1);
+    display.println(" DASHBOARD");
+    while (true)
+    {
+      display.setCursor(0, 4);
+      display.println(" DISABLED ");
+      wait = millis() + 500;
+      while (wait>millis());
+      display.setCursor(0, 4);
+      display.println("          ");
+      wait = millis() + 200;
+      while (wait>millis());
+    }
+  }
+
   if ((S25C31.current == 0) && (S25C31.voltage == 0) && (S25C31.remainPercent == 0)) {
     displayClear(1);
     display.set2X();


### PR DESCRIPTION
Turn on the scooter and immediately engage and hold the throttle and brake before the logo disappears from the dashboard LCD. You will enter on dashboard disabled mode.
The Arduino TX/RX pins will go to hi impedance state leaving the communication BUS free.

By this way you can update de M365 firmware without disconnecting the dashboard or any cable.

A new power cycle will reset the dashboard to normal mode.
![disabledView](https://user-images.githubusercontent.com/5514002/56957873-d3fe8180-6b48-11e9-979a-17aa005a51f7.jpg)